### PR TITLE
feat: create initramfs crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# IDE files
+.idea/
+.vscode/

--- a/initramfs/Cargo.toml
+++ b/initramfs/Cargo.toml
@@ -6,3 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reqwest = { version = "0.11.13", features = ["json"] }
+tokio = { version = "1.23.0", features = ["full"] }
+log = { version = "0.4.17" }
+thiserror = { version = "1.0.37" }
+anyhow = { version = "1.0.66" }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+clap = { version = "4.0.29", features = ["derive"] }
+env_logger = { version = "0.10.0" }
+flate2 = { version = "1.0.25" }
+tar = { version = "0.4.38" }
+bytes = "1.4.0"
+libflate = "0.1"
+cpio = "0.2.2"

--- a/initramfs/src/httpclient.rs
+++ b/initramfs/src/httpclient.rs
@@ -1,0 +1,19 @@
+use anyhow::{anyhow, Result};
+use reqwest::{Client, Response};
+
+pub async fn run_get_request(url: &str, token: Option<&str>) -> Result<Response> {
+    let res = match token {
+        Some(token) => Client::new().get(url).bearer_auth(token.clone()),
+        None => Client::new().get(url),
+    }
+    .send()
+    .await
+    .map_err(|e| anyhow!(e).context(format!("Failed to run request to {}", url)))?;
+
+    if !res.status().is_success() {
+        return Err(anyhow!(res.text().await.unwrap_or_default())
+            .context(format!("Failed to get a success response from {}", url)));
+    }
+
+    Ok(res)
+}

--- a/initramfs/src/image.rs
+++ b/initramfs/src/image.rs
@@ -1,0 +1,168 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{Cursor, Read},
+    os::unix::fs::PermissionsExt,
+};
+
+use anyhow::{anyhow, Result};
+use bytes::Bytes;
+use cpio::{newc::Builder, write_cpio};
+use libflate::gzip::{Decoder, Encoder};
+use log::debug;
+use serde::Deserialize;
+use tar::Archive;
+
+#[derive(Deserialize, Debug, Clone)]
+#[allow(non_snake_case)]
+pub struct LayerMetadata {
+    pub blobSum: String,
+}
+
+#[derive(Clone)]
+pub struct Layer {
+    pub metadata: LayerMetadata,
+    pub content: Cursor<Bytes>,
+}
+
+pub struct Image {
+    name: String,
+    tag: String,
+    pub layers: Vec<Layer>,
+}
+
+impl Image {
+    pub fn new(full_name: &str) -> Result<Self> {
+        // Extract the registry and tag from the image
+        let mut parts = full_name.split(':');
+        let name = parts.next().ok_or_else(|| anyhow!("Invalid image name"))?;
+        let tag = parts.next().unwrap_or("latest");
+
+        // If the registry doesn't contain a '/', it's in "library/", meaning it's from the docker hub official images
+        let image = Self {
+            name: if !name.contains('/') {
+                format!("library/{}", name)
+            } else {
+                name.to_string()
+            },
+            tag: tag.to_string(),
+            layers: Vec::new(),
+        };
+
+        debug!("Successfully parsed image : {:?}", image.name());
+
+        Ok(image)
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    pub fn export_to_initramfs(&self, init_path: &str, agent_path: &str) -> Result<()> {
+        // Write the cpio to disk
+        let file_name = format!("initramfs-{}-{}.img", self.name.replace("/", "-"), self.tag);
+        let archive = Encoder::new(
+            File::create(file_name).map_err(|e| anyhow!(e).context("Failed to create file"))?,
+        )
+        .map_err(|e| anyhow!(e).context("Failed to create gzip encoder"))?;
+
+        let mut entries = HashMap::new();
+
+        for layer in self.layers.clone() {
+            let mut archive = Archive::new(Decoder::new(layer.content)?);
+
+            for entry in archive
+                .entries()
+                .map_err(|e| anyhow!(e).context("Failed to get archive entries"))?
+            {
+                let mut entry = entry.map_err(|e| anyhow!(e).context("Failed to get entry"))?;
+                let headers = entry.header();
+                let path = headers
+                    .path()
+                    .map_err(|e| anyhow!(e).context("Failed to get path of entry"))?
+                    .to_str()
+                    .ok_or_else(|| anyhow!("Failed to convert path to string"))?
+                    .to_string();
+
+                if entries.contains_key(&path) {
+                    continue;
+                }
+
+                let mode = headers
+                    .mode()
+                    .map_err(|e| anyhow!(e).context("Failed to get mode of entry"))?;
+
+                let builder = Builder::new(&path)
+                    .uid(
+                        headers
+                            .uid()
+                            .map_err(|e| anyhow!(e).context("Failed to get uid of entry"))?
+                            as u32,
+                    )
+                    .gid(
+                        headers
+                            .gid()
+                            .map_err(|e| anyhow!(e).context("Failed to get gid of entry"))?
+                            as u32,
+                    )
+                    .mode(mode);
+
+                debug!("Adding {} to archive", &path);
+
+                let mut contents = Vec::new();
+                entry
+                    .read_to_end(&mut contents)
+                    .map_err(|e| anyhow!(e).context("Failed to read entry"))?;
+
+                entries.insert(path, (builder, Cursor::new(contents)));
+            }
+        }
+
+        let mut init_file =
+            File::open(init_path).map_err(|e| anyhow!(e).context("Failed to open init file"))?;
+        let mut agent_file =
+            File::open(agent_path).map_err(|e| anyhow!(e).context("Failed to open init file"))?;
+
+        let mut init_content = Vec::new();
+        let mut agent_content = Vec::new();
+
+        init_file.read_to_end(&mut init_content)?;
+        agent_file.read_to_end(&mut agent_content)?;
+
+        let init_mode = init_file.metadata()?.permissions().mode();
+        let agent_mode = agent_file.metadata()?.permissions().mode();
+
+        entries.insert(
+            "init".to_string(),
+            (
+                Builder::new("init").mode(init_mode),
+                Cursor::new(init_content),
+            ),
+        );
+        entries.insert(
+            "agent".to_string(),
+            (
+                Builder::new("agent").mode(agent_mode),
+                Cursor::new(agent_content),
+            ),
+        );
+
+        let test = entries
+            .drain()
+            .map(|(_, (builder, contents))| (builder, contents));
+        let archive =
+            write_cpio(test, archive).map_err(|e| anyhow!(e).context("Failed to write cpio"))?;
+        archive
+            .finish()
+            .into_result()
+            .map_err(|e| anyhow!(e).context("Failed to finish writing cpio"))?;
+
+        debug!("Successfully wrote cpio to disk");
+
+        Ok(())
+    }
+}

--- a/initramfs/src/lib.rs
+++ b/initramfs/src/lib.rs
@@ -1,8 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}

--- a/initramfs/src/main.rs
+++ b/initramfs/src/main.rs
@@ -1,0 +1,63 @@
+use anyhow::anyhow;
+use clap::Parser;
+use env_logger::Env;
+use log::{debug, info};
+
+use crate::registry::Registry;
+
+mod httpclient;
+mod image;
+mod registry;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    image: String,
+
+    #[arg(long, default_value = "./init")]
+    init: String,
+
+    #[arg(long, default_value = "./agent")]
+    agent: String,
+
+    #[arg(
+        short,
+        long,
+        default_value = "https://auth.docker.io/token",
+        value_name = "auth"
+    )]
+    auth_url: String,
+
+    #[arg(
+        short,
+        long,
+        default_value = "https://registry-1.docker.io/v2",
+        value_name = "registry"
+    )]
+    registry_url: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the logger
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    // Parse the cli arguments
+    let args = Args::parse();
+    debug!("Running cli with arguments : {:?}", args);
+
+    let registry = Registry::new(&args.registry_url, &args.auth_url);
+
+    info!("Downloading image {}", &args.image);
+    let image = registry.get_image(&args.image).await?;
+    info!("Download done!");
+
+    info!("Writing  to disk ...");
+    image
+        .export_to_initramfs(&args.init, &args.agent)
+        .map_err(|e| anyhow!(e).context("Failed to write filesystem to disk"))?;
+    info!("Writing done!");
+
+    Ok(())
+}

--- a/initramfs/src/registry.rs
+++ b/initramfs/src/registry.rs
@@ -1,0 +1,152 @@
+use std::io::Cursor;
+
+use anyhow::{anyhow, Result};
+use log::{debug, info};
+use serde::Deserialize;
+
+use crate::{
+    httpclient::run_get_request,
+    image::{Image, Layer, LayerMetadata},
+};
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    token: String,
+}
+
+#[derive(Deserialize)]
+#[allow(non_snake_case)]
+struct ManifestResponse {
+    fsLayers: Vec<LayerMetadata>,
+}
+
+pub struct Registry {
+    url: String,
+    auth_url: String,
+}
+
+impl Registry {
+    pub fn new(url: &str, auth_url: &str) -> Self {
+        Self {
+            url: url.to_string(),
+            auth_url: auth_url.to_string(),
+        }
+    }
+
+    async fn get_token(&self, image_name: &str) -> Result<String> {
+        let res = run_get_request(
+            &format!(
+                "{}?service=registry.docker.io&scope=repository:{}:pull",
+                self.auth_url, image_name
+            ),
+            None,
+        )
+        .await?;
+
+        // Extract the token from the response
+        let token = res
+            .json::<TokenResponse>()
+            .await
+            .map_err(|e| anyhow!(e).context("Failed to parse response"))?
+            .token;
+
+        debug!("Successfully got auth token : {:?}", token);
+
+        Ok(token)
+    }
+
+    async fn get_layers_metadata(
+        &self,
+        token: &str,
+        image_name: &str,
+        image_tag: &str,
+    ) -> Result<Vec<LayerMetadata>> {
+        let res = run_get_request(
+            &format!("{}/{}/manifests/{}", self.url, image_name, image_tag),
+            Some(token),
+        )
+        .await?;
+
+        // Extract the information about the layers from the manifest
+        let layers_metadata = res
+            .json::<ManifestResponse>()
+            .await
+            .map_err(|e| anyhow!(e).context("Failed to parse response"))?
+            .fsLayers;
+
+        debug!("Successfully got layers : {:?}", layers_metadata);
+
+        Ok(layers_metadata)
+    }
+
+    async fn get_layer(
+        &self,
+        token: &str,
+        image_name: &str,
+        layer_metadata: &LayerMetadata,
+    ) -> Result<Layer> {
+        // Make a request to the docker hub to get the layer from his blobSum
+        let res = run_get_request(
+            &format!(
+                "{}/{}/blobs/{}",
+                self.url, image_name, layer_metadata.blobSum
+            ),
+            Some(token),
+        )
+        .await?;
+
+        // Wrap the response into a tar archive (memory loaded)
+        let buff = Cursor::new(
+            res.bytes()
+                .await
+                .map_err(|e| anyhow!(e).context("Failed to read response"))?,
+        );
+
+        debug!("Successfully wrote layer to memory");
+
+        Ok(Layer {
+            metadata: (*layer_metadata).clone(),
+            content: buff,
+        })
+    }
+
+    async fn get_layers(
+        &self,
+        token: &str,
+        image_name: &str,
+        layers_metadata: Vec<LayerMetadata>,
+    ) -> Result<Vec<Layer>> {
+        let mut layers = Vec::new();
+        for layer_metadata in layers_metadata.iter() {
+            info!("Pulling layer {:?}", layer_metadata.blobSum);
+
+            let layer = self
+                .get_layer(token, image_name, layer_metadata)
+                .await
+                .map_err(|e| anyhow!(e).context("Failed to pull layer"))?;
+            layers.push(layer);
+
+            debug!("Successfully pulled layer : {:?}", layer_metadata.blobSum);
+        }
+
+        debug!("Successfully pulled all layers");
+
+        Ok(layers)
+    }
+
+    pub async fn get_image(&self, image_full_name: &str) -> Result<Image> {
+        let mut image = Image::new(image_full_name)?;
+        let image_name = image.name();
+        let token = self.get_token(&image_name).await?;
+        let layers_metadata = self
+            .get_layers_metadata(&token, &image_name, &image.tag())
+            .await?;
+        let layers = self
+            .get_layers(&token, &image_name, layers_metadata)
+            .await?;
+
+        image.layers = layers;
+
+        Ok(image)
+    }
+}


### PR DESCRIPTION
Implement a crate `initramfs` that pull docker images and wrap them into an initramfs that can be loaded into `lumper`.